### PR TITLE
Add test for gem push

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.14.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
       <version>${vertx.version}</version>

--- a/src/test/java/com/artipie/gem/GemCliITCase.java
+++ b/src/test/java/com/artipie/gem/GemCliITCase.java
@@ -24,47 +24,67 @@
 package com.artipie.gem;
 
 import com.artipie.asto.memory.InMemoryStorage;
-import com.artipie.http.rs.RsStatus;
 import com.artipie.vertx.VertxSliceServer;
 import io.vertx.reactivex.core.Vertx;
-import io.vertx.reactivex.core.buffer.Buffer;
-import io.vertx.reactivex.ext.web.client.WebClient;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
 
 /**
- * A test for gem submit operation.
+ * A test which ensures {@code gem} console tool compatibility with the adapter.
  *
  * @since 0.2
+ * @checkstyle StringLiteralsConcatenationCheck (500 lines)
  */
-public class SubmitGemITCase {
+@SuppressWarnings("PMD.SystemPrintln")
+@DisabledIfSystemProperty(named = "os.name", matches = "Windows.*")
+public class GemCliITCase {
 
     @Test
-    public void submitNotImplemented() throws IOException {
+    public void gemPushWorks() throws IOException, InterruptedException {
         final Vertx vertx = Vertx.vertx();
         final VertxSliceServer server = new VertxSliceServer(
             vertx,
             new GemSlice(new InMemoryStorage(), vertx.fileSystem())
         );
-        final WebClient web = WebClient.create(vertx);
         final int port = server.start();
-        final byte[] gem = Files.readAllBytes(
-            Paths.get("./src/test/resources/builder-3.2.4.gem")
+        final String host = String.format("http://host.testcontainers.internal:%d", port);
+        Testcontainers.exposeHostPorts(port);
+        final RubyContainer ruby = new RubyContainer()
+            .withCommand("tail", "-f", "/dev/null")
+            .withWorkingDirectory("/home/")
+            .withFileSystemBind("./src/test/resources", "/home");
+        ruby.start();
+        final Container.ExecResult push = ruby.execInContainer(
+            "/bin/bash",
+            "-c",
+            String.format("GEM_HOST_API_KEY=123 gem push builder-3.2.4.gem --host %s", host)
         );
-        final int code = web.post(port, "localhost", "/api/v1/gems")
-            .rxSendBuffer(Buffer.buffer(gem))
-            .blockingGet()
-            .statusCode();
+        System.out.println(push.getStdout());
+        System.err.println(push.getStderr());
         MatcherAssert.assertThat(
-            code,
-            new IsEqual<>(Integer.parseInt(RsStatus.OK.code()))
+            String.format("'gem push builder-3.2.4.gem --host %s' failed with non-zero code", host),
+            push.getExitCode(),
+            Matchers.equalTo(0)
         );
-        web.close();
+        ruby.stop();
         server.close();
         vertx.close();
+    }
+
+    /**
+     * Inner subclass to instantiate Ruby container.
+     *
+     * @since 0.1
+     */
+    private static class RubyContainer extends GenericContainer<RubyContainer> {
+        RubyContainer() {
+            super("ruby:2.7");
+        }
     }
 }

--- a/src/test/java/com/artipie/gem/GemCliITCase.java
+++ b/src/test/java/com/artipie/gem/GemCliITCase.java
@@ -25,6 +25,7 @@ package com.artipie.gem;
 
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.vertx.VertxSliceServer;
+import com.jcabi.log.Logger;
 import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
@@ -65,8 +66,8 @@ public class GemCliITCase {
             "-c",
             String.format("GEM_HOST_API_KEY=123 gem push builder-3.2.4.gem --host %s", host)
         );
-        System.out.println(push.getStdout());
-        System.err.println(push.getStderr());
+        Logger.info(GemCliITCase.class, push.getStdout());
+        Logger.error(GemCliITCase.class, push.getStderr());
         MatcherAssert.assertThat(
             String.format("'gem push builder-3.2.4.gem --host %s' failed with non-zero code", host),
             push.getExitCode(),

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,7 +1,8 @@
-log4j.rootLogger=WARN, CONSOLE
+log4j.rootLogger=INFO, CONSOLE
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=com.jcabi.log.MulticolorLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=[%color{%p}] %t %c: %m%n
 
 log4j.logger.com.artipie=DEBUG
+log4j.logger.org.testcontainers=DEBUG


### PR DESCRIPTION
The test ensures that gem-adapter is compatible with `gem push` operation.

The test is disabled on windows since testcontainers does not support Windows