### PR TITLE
Initial auth support

### DIFF
--- a/src/main/java/com/artipie/gem/ApiKeySlice.java
+++ b/src/main/java/com/artipie/gem/ApiKeySlice.java
@@ -77,7 +77,7 @@ public final class ApiKeySlice implements Slice {
                 .get();
             response = new RsWithBody(key, StandardCharsets.UTF_8);
         } else {
-            response = new RsWithStatus(RsStatus.FORBIDDEN);
+            response = new RsWithStatus(RsStatus.UNAUTHORIZED);
         }
         return response;
     }

--- a/src/main/java/com/artipie/gem/ApiKeySlice.java
+++ b/src/main/java/com/artipie/gem/ApiKeySlice.java
@@ -1,24 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.artipie.gem;
 
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.auth.Identities;
-import com.artipie.http.auth.Permissions;
-import java.nio.ByteBuffer;
-import java.util.Map;
-import java.util.Optional;
 import com.artipie.http.headers.Authorization;
 import com.artipie.http.rq.RqHeaders;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.RsWithStatus;
-import com.google.common.base.Charsets;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
 import org.reactivestreams.Publisher;
 
 /**
  * Responses on api key requests.
+ *
+ * @since 0.3
  */
-public class ApiKeySlice implements Slice {
+public final class ApiKeySlice implements Slice {
 
     /**
      * Basic authentication prefix.
@@ -26,22 +50,15 @@ public class ApiKeySlice implements Slice {
     private static final String PREFIX = "Basic ";
 
     /**
-     * The perms.
-     */
-    private Permissions perms;
-
-    /**
      * The users.
      */
-    private Identities users;
+    private final Identities users;
 
     /**
      * The Ctor.
-     * @param perms The perms.
      * @param users The users.
      */
-    public ApiKeySlice(final Permissions perms, final Identities users) {
-        this.perms = perms;
+    public ApiKeySlice(final Identities users) {
         this.users = users;
     }
 
@@ -58,7 +75,7 @@ public class ApiKeySlice implements Slice {
                 .filter(hdr -> hdr.startsWith(ApiKeySlice.PREFIX))
                 .map(hdr -> hdr.substring(ApiKeySlice.PREFIX.length()))
                 .get();
-            response = new RsWithBody(key, Charsets.UTF_8);
+            response = new RsWithBody(key, StandardCharsets.UTF_8);
         } else {
             response = new RsWithStatus(RsStatus.FORBIDDEN);
         }

--- a/src/main/java/com/artipie/gem/ApiKeySlice.java
+++ b/src/main/java/com/artipie/gem/ApiKeySlice.java
@@ -1,0 +1,67 @@
+package com.artipie.gem;
+
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.auth.Identities;
+import com.artipie.http.auth.Permissions;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+import com.artipie.http.headers.Authorization;
+import com.artipie.http.rq.RqHeaders;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithStatus;
+import com.google.common.base.Charsets;
+import org.reactivestreams.Publisher;
+
+/**
+ * Responses on api key requests.
+ */
+public class ApiKeySlice implements Slice {
+
+    /**
+     * Basic authentication prefix.
+     */
+    private static final String PREFIX = "Basic ";
+
+    /**
+     * The perms.
+     */
+    private Permissions perms;
+
+    /**
+     * The users.
+     */
+    private Identities users;
+
+    /**
+     * The Ctor.
+     * @param perms The perms.
+     * @param users The users.
+     */
+    public ApiKeySlice(final Permissions perms, final Identities users) {
+        this.perms = perms;
+        this.users = users;
+    }
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body) {
+        final Response response;
+        final Optional<String> user = this.users.user(line, headers);
+        if (user.isPresent()) {
+            final String key = new RqHeaders(headers, Authorization.NAME).stream()
+                .findFirst()
+                .filter(hdr -> hdr.startsWith(ApiKeySlice.PREFIX))
+                .map(hdr -> hdr.substring(ApiKeySlice.PREFIX.length()))
+                .get();
+            response = new RsWithBody(key, Charsets.UTF_8);
+        } else {
+            response = new RsWithStatus(RsStatus.FORBIDDEN);
+        }
+        return response;
+    }
+}

--- a/src/main/java/com/artipie/gem/GemSlice.java
+++ b/src/main/java/com/artipie/gem/GemSlice.java
@@ -75,7 +75,6 @@ public final class GemSlice extends Slice.Wrap {
      *
      * @param storage The storage.
      * @param runtime The Jruby runtime.
-     * @param perms The perms.
      * @param users The users.
      */
     public GemSlice(final Storage storage,

--- a/src/main/java/com/artipie/gem/GemSlice.java
+++ b/src/main/java/com/artipie/gem/GemSlice.java
@@ -26,7 +26,6 @@ package com.artipie.gem;
 import com.artipie.asto.Storage;
 import com.artipie.http.Slice;
 import com.artipie.http.auth.Identities;
-import com.artipie.http.auth.Permissions;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithStatus;
@@ -68,7 +67,6 @@ public final class GemSlice extends Slice.Wrap {
     public GemSlice(final Storage storage) {
         this(storage,
             JavaEmbedUtils.initialize(new ArrayList<>(0)),
-            Permissions.FREE,
             Identities.ANONYMOUS);
     }
 
@@ -82,7 +80,6 @@ public final class GemSlice extends Slice.Wrap {
      */
     public GemSlice(final Storage storage,
         final Ruby runtime,
-        final Permissions perms,
         final Identities users) {
         super(
             new SliceRoute(

--- a/src/main/java/com/artipie/gem/GemSlice.java
+++ b/src/main/java/com/artipie/gem/GemSlice.java
@@ -57,7 +57,7 @@ import org.jruby.javasupport.JavaEmbedUtils;
  * @checkstyle MethodBodyCommentsCheck (500 lines)
  * @since 0.1
  */
-@SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+@SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField", "PMD.UnusedFormalParameter"})
 public final class GemSlice extends Slice.Wrap {
 
     /**
@@ -77,11 +77,13 @@ public final class GemSlice extends Slice.Wrap {
      *
      * @param storage The storage.
      * @param runtime The Jruby runtime.
+     * @param perms The perms.
+     * @param users The users.
      */
     public GemSlice(final Storage storage,
-                    final Ruby runtime,
-                    final Permissions perms,
-                    final Identities users) {
+        final Ruby runtime,
+        final Permissions perms,
+        final Identities users) {
         super(
             new SliceRoute(
                 new RtRulePath(
@@ -96,7 +98,7 @@ public final class GemSlice extends Slice.Wrap {
                         new RtRule.ByMethod(RqMethod.GET),
                         new RtRule.ByPath("/api/v1/api_key")
                     ),
-                    new ApiKeySlice(perms, users)
+                    new ApiKeySlice(users)
                 ),
                 new RtRulePath(
                     new RtRule.All(

--- a/src/main/java/com/artipie/gem/GemSlice.java
+++ b/src/main/java/com/artipie/gem/GemSlice.java
@@ -56,7 +56,7 @@ import org.jruby.javasupport.JavaEmbedUtils;
  * @checkstyle MethodBodyCommentsCheck (500 lines)
  * @since 0.1
  */
-@SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField", "PMD.UnusedFormalParameter"})
+@SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
 public final class GemSlice extends Slice.Wrap {
 
     /**

--- a/src/test/java/com/artipie/gem/ApiKeyTest.java
+++ b/src/test/java/com/artipie/gem/ApiKeyTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.3
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public class ApiKeyTest {
 
     @Test
@@ -61,7 +62,7 @@ public class ApiKeyTest {
     }
 
     @Test
-    public void secondBranch(){
+    public void secondBranch() {
         final String token = "aGVsbG86d29ybGQ=";
         final ArrayList<Map.Entry<String, String>> headers = new ArrayList<>(0);
         headers.add(new Authorization(String.format("Basic %s", token)));

--- a/src/test/java/com/artipie/gem/ApiKeyTest.java
+++ b/src/test/java/com/artipie/gem/ApiKeyTest.java
@@ -24,6 +24,7 @@
 package com.artipie.gem;
 
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.http.Headers;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Authorization;
 import com.artipie.http.hm.RsHasBody;
@@ -50,8 +51,7 @@ public class ApiKeyTest {
     @Test
     public void keyIsReturned() {
         final String token = "aGVsbG86d29ybGQ=";
-        final ArrayList<Map.Entry<String, String>> headers = new ArrayList<>(0);
-        headers.add(new Authorization(String.format("Basic %s", token)));
+        final Headers headers = new Headers.From(new Authorization(String.format("Basic %s", token)));
         MatcherAssert.assertThat(
             new GemSlice(new InMemoryStorage()).response(
                 new RequestLine("GET", "/api/v1/api_key").toString(),
@@ -63,9 +63,6 @@ public class ApiKeyTest {
 
     @Test
     public void secondBranch() {
-        final String token = "aGVsbG86d29ybGQ=";
-        final ArrayList<Map.Entry<String, String>> headers = new ArrayList<>(0);
-        headers.add(new Authorization(String.format("Basic %s", token)));
         MatcherAssert.assertThat(
             new GemSlice(
                 new InMemoryStorage(),
@@ -74,7 +71,7 @@ public class ApiKeyTest {
                 (line, iterable) -> Optional.empty()
             ).response(
                 new RequestLine("GET", "/api/v1/api_key").toString(),
-                headers,
+                new Headers.From(),
                 Flowable.empty()
             ), new RsHasStatus(RsStatus.UNAUTHORIZED)
         );

--- a/src/test/java/com/artipie/gem/ApiKeyTest.java
+++ b/src/test/java/com/artipie/gem/ApiKeyTest.java
@@ -34,7 +34,6 @@ import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.jruby.javasupport.JavaEmbedUtils;
@@ -51,7 +50,9 @@ public class ApiKeyTest {
     @Test
     public void keyIsReturned() {
         final String token = "aGVsbG86d29ybGQ=";
-        final Headers headers = new Headers.From(new Authorization(String.format("Basic %s", token)));
+        final Headers headers = new Headers.From(
+            new Authorization(String.format("Basic %s", token))
+        );
         MatcherAssert.assertThat(
             new GemSlice(new InMemoryStorage()).response(
                 new RequestLine("GET", "/api/v1/api_key").toString(),

--- a/src/test/java/com/artipie/gem/ApiKeyTest.java
+++ b/src/test/java/com/artipie/gem/ApiKeyTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.gem;
+
+import com.artipie.http.auth.Identities;
+import com.artipie.http.headers.Authorization;
+import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.rq.RequestLine;
+import io.reactivex.Flowable;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A test for api key endpoint.
+ *
+ * @since 0.2
+ * @checkstyle StringLiteralsConcatenationCheck (500 lines)
+ */
+public class ApiKeyTest {
+
+    @Test
+    public void keyIsReturned() {
+        final String token = "aGVsbG86d29ybGQ=";
+        final ArrayList<Map.Entry<String, String>> headers = new ArrayList<>(0);
+        headers.add(new Authorization(String.format("Basic %s", token)));
+        MatcherAssert.assertThat(
+            new ApiKeySlice(Identities.ANONYMOUS).response(
+                new RequestLine("GET", "/").toString(),
+                headers,
+                Flowable.empty()
+            ), new RsHasBody(token.getBytes(StandardCharsets.UTF_8))
+        );
+    }
+}

--- a/src/test/java/com/artipie/gem/ApiKeyTest.java
+++ b/src/test/java/com/artipie/gem/ApiKeyTest.java
@@ -25,7 +25,6 @@ package com.artipie.gem;
 
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.http.Headers;
-import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Authorization;
 import com.artipie.http.hm.RsHasBody;
 import com.artipie.http.hm.RsHasStatus;
@@ -68,7 +67,6 @@ public class ApiKeyTest {
             new GemSlice(
                 new InMemoryStorage(),
                 JavaEmbedUtils.initialize(new ArrayList<>(0)),
-                Permissions.FREE,
                 (line, iterable) -> Optional.empty()
             ).response(
                 new RequestLine("GET", "/api/v1/api_key").toString(),

--- a/src/test/java/com/artipie/gem/ApiKeyTest.java
+++ b/src/test/java/com/artipie/gem/ApiKeyTest.java
@@ -62,7 +62,7 @@ public class ApiKeyTest {
     }
 
     @Test
-    public void secondBranch() {
+    public void unauthorizedWhenNoIdentity() {
         MatcherAssert.assertThat(
             new GemSlice(
                 new InMemoryStorage(),

--- a/src/test/java/com/artipie/gem/ApiKeyTest.java
+++ b/src/test/java/com/artipie/gem/ApiKeyTest.java
@@ -24,14 +24,19 @@
 package com.artipie.gem;
 
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Authorization;
 import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Optional;
 import org.hamcrest.MatcherAssert;
+import org.jruby.javasupport.JavaEmbedUtils;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -52,6 +57,25 @@ public class ApiKeyTest {
                 headers,
                 Flowable.empty()
             ), new RsHasBody(token.getBytes(StandardCharsets.UTF_8))
+        );
+    }
+
+    @Test
+    public void secondBranch(){
+        final String token = "aGVsbG86d29ybGQ=";
+        final ArrayList<Map.Entry<String, String>> headers = new ArrayList<>(0);
+        headers.add(new Authorization(String.format("Basic %s", token)));
+        MatcherAssert.assertThat(
+            new GemSlice(
+                new InMemoryStorage(),
+                JavaEmbedUtils.initialize(new ArrayList<>(0)),
+                Permissions.FREE,
+                (line, iterable) -> Optional.empty()
+            ).response(
+                new RequestLine("GET", "/api/v1/api_key").toString(),
+                headers,
+                Flowable.empty()
+            ), new RsHasStatus(RsStatus.UNAUTHORIZED)
         );
     }
 }

--- a/src/test/java/com/artipie/gem/ApiKeyTest.java
+++ b/src/test/java/com/artipie/gem/ApiKeyTest.java
@@ -23,7 +23,7 @@
  */
 package com.artipie.gem;
 
-import com.artipie.http.auth.Identities;
+import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.http.headers.Authorization;
 import com.artipie.http.hm.RsHasBody;
 import com.artipie.http.rq.RequestLine;
@@ -37,8 +37,7 @@ import org.junit.jupiter.api.Test;
 /**
  * A test for api key endpoint.
  *
- * @since 0.2
- * @checkstyle StringLiteralsConcatenationCheck (500 lines)
+ * @since 0.3
  */
 public class ApiKeyTest {
 
@@ -48,8 +47,8 @@ public class ApiKeyTest {
         final ArrayList<Map.Entry<String, String>> headers = new ArrayList<>(0);
         headers.add(new Authorization(String.format("Basic %s", token)));
         MatcherAssert.assertThat(
-            new ApiKeySlice(Identities.ANONYMOUS).response(
-                new RequestLine("GET", "/").toString(),
+            new GemSlice(new InMemoryStorage()).response(
+                new RequestLine("GET", "/api/v1/api_key").toString(),
                 headers,
                 Flowable.empty()
             ), new RsHasBody(token.getBytes(StandardCharsets.UTF_8))


### PR DESCRIPTION
Use base64 encrypted credentials as an API key.

Related to #45