### PR TITLE
Use random name for temp dir

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -32,3 +32,5 @@ architect:
   - g4s8
   - yegor256
   - Sammers21
+  - olegmoz
+  - olenagerasimova

--- a/src/main/java/com/artipie/gem/GemSlice.java
+++ b/src/main/java/com/artipie/gem/GemSlice.java
@@ -77,7 +77,8 @@ public final class GemSlice extends Slice.Wrap {
         this(storage,
             JavaEmbedUtils.initialize(new ArrayList<>(0)),
             Permissions.FREE,
-            (login, pwd) -> Optional.of(new Authentication.User("anonymous"))
+            (login, pwd) -> Optional.of(new Authentication.User("anonymous")),
+            "default"
         );
     }
 
@@ -88,11 +89,13 @@ public final class GemSlice extends Slice.Wrap {
      * @param runtime The Jruby runtime.
      * @param permissions The permissions.
      * @param auth The auth.
+     * @param repo The repo identifier.
      */
     public GemSlice(final Storage storage,
         final Ruby runtime,
         final Permissions permissions,
-        final Authentication auth) {
+        final Authentication auth,
+        final String repo) {
         super(
             new SliceRoute(
                 new RtRulePath(
@@ -105,7 +108,7 @@ public final class GemSlice extends Slice.Wrap {
                             runtime,
                             "SubmitGem",
                             storage,
-                            GemSlice.tmpDir()
+                            GemSlice.tmpDirForRepo(repo)
                         ),
                         new Permission.ByName(permissions, Action.Standard.WRITE),
                         new GemApiKeyIdentities(auth)
@@ -173,13 +176,14 @@ public final class GemSlice extends Slice.Wrap {
 
     /**
      * Temp dir, which will be removed on jvm exit.
+     * @param repo The repo identifier.
      * @return The dir name.
      */
-    private static String tmpDir() {
+    private static String tmpDirForRepo(final String repo) {
         final String fname = String.join(
             "-",
-            "gem-tmp-index",
-            UUID.randomUUID().toString()
+            repo,
+            "gem-tmp-index"
         );
         Runtime.getRuntime().addShutdownHook(
             new Thread(

--- a/src/main/java/com/artipie/gem/GemSlice.java
+++ b/src/main/java/com/artipie/gem/GemSlice.java
@@ -185,17 +185,6 @@ public final class GemSlice extends Slice.Wrap {
             repo,
             "gem-tmp-index"
         );
-        Runtime.getRuntime().addShutdownHook(
-            new Thread(
-                () -> {
-                    try {
-                        FileUtils.deleteDirectory(new File(fname));
-                    } catch (final IOException exc) {
-                        throw new UncheckedIOException(exc);
-                    }
-                }
-            )
-        );
         return fname;
     }
 }

--- a/src/main/java/com/artipie/gem/GemSlice.java
+++ b/src/main/java/com/artipie/gem/GemSlice.java
@@ -156,7 +156,7 @@ public final class GemSlice extends Slice.Wrap {
     }
 
     /**
-     * Temp dir, which will be removed on jvm exit.
+     * Temp dir for index generation.
      * @param repo The repo identifier.
      * @return The dir name.
      */

--- a/src/main/java/com/artipie/gem/GemSlice.java
+++ b/src/main/java/com/artipie/gem/GemSlice.java
@@ -39,13 +39,9 @@ import com.artipie.http.rt.RtRulePath;
 import com.artipie.http.rt.SliceRoute;
 import com.artipie.http.slice.SliceDownload;
 import com.artipie.http.slice.SliceSimple;
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Optional;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyRuntimeAdapter;
@@ -66,20 +62,6 @@ import org.jruby.javasupport.JavaEmbedUtils;
  */
 @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
 public final class GemSlice extends Slice.Wrap {
-
-    /**
-     * Ctor.
-     *
-     * @param storage The storage.
-     */
-    public GemSlice(final Storage storage) {
-        this(storage,
-            JavaEmbedUtils.initialize(new ArrayList<>(0)),
-            Permissions.FREE,
-            (login, pwd) -> Optional.of(new Authentication.User("anonymous")),
-            "default"
-        );
-    }
 
     /**
      * Ctor.

--- a/src/main/ruby/SubmitGem.rb
+++ b/src/main/ruby/SubmitGem.rb
@@ -29,9 +29,9 @@ class SubmitGem
 
   @@log = LoggerFactory::getLogger("com.artipie.gem.SubmitGem")
 
-  def initialize(storage)
+  def initialize(storage, idxdir)
     @storage = storage
-    @idx = "temp-gem-index"
+    @idx = idxdir
     @gems = File.join(@idx, "gems")
     # Was index created before?
     idx_existed = File.exists?(@idx)

--- a/src/test/java/com/artipie/gem/AuthTest.java
+++ b/src/test/java/com/artipie/gem/AuthTest.java
@@ -59,7 +59,13 @@ public class AuthTest {
             new Authorization(String.format("Basic %s", token))
         );
         MatcherAssert.assertThat(
-            new GemSlice(new InMemoryStorage()).response(
+            new GemSlice(
+                new InMemoryStorage(),
+                JavaEmbedUtils.initialize(new ArrayList<>(0)),
+                Permissions.FREE,
+                (login, pwd) -> Optional.of(new Authentication.User("anonymous")),
+                "keyIsReturned"
+            ).response(
                 new RequestLine("GET", "/api/v1/api_key").toString(),
                 headers,
                 Flowable.empty()
@@ -75,7 +81,7 @@ public class AuthTest {
                 JavaEmbedUtils.initialize(new ArrayList<>(0)),
                 Permissions.FREE,
                 (lgn, pwd) -> Optional.empty(),
-                "def"
+                "unauthorizedWhenNoIdentity"
             ).response(
                 new RequestLine("GET", "/api/v1/api_key").toString(),
                 new Headers.From(),
@@ -101,7 +107,7 @@ public class AuthTest {
                         return Optional.empty();
                     }
                 },
-                "default"
+                "notAllowedToPushUsersAreRejected"
             ).response(
                 new RequestLine("POST", "/api/v1/gems").toString(),
                 new Headers.From(new Authorization(token)),
@@ -127,7 +133,7 @@ public class AuthTest {
                         return Optional.empty();
                     }
                 },
-                "default"
+                "notAllowedToInstallsUsersAreRejected"
             ).response(
                 new RequestLine("GET", "specs.4.8").toString(),
                 new Headers.From(new Authorization(token)),

--- a/src/test/java/com/artipie/gem/AuthTest.java
+++ b/src/test/java/com/artipie/gem/AuthTest.java
@@ -74,7 +74,8 @@ public class AuthTest {
                 new InMemoryStorage(),
                 JavaEmbedUtils.initialize(new ArrayList<>(0)),
                 Permissions.FREE,
-                (lgn, pwd) -> Optional.empty()
+                (lgn, pwd) -> Optional.empty(),
+                "def"
             ).response(
                 new RequestLine("GET", "/api/v1/api_key").toString(),
                 new Headers.From(),
@@ -99,7 +100,8 @@ public class AuthTest {
                     } else {
                         return Optional.empty();
                     }
-                }
+                },
+                "default"
             ).response(
                 new RequestLine("POST", "/api/v1/gems").toString(),
                 new Headers.From(new Authorization(token)),
@@ -124,7 +126,8 @@ public class AuthTest {
                     } else {
                         return Optional.empty();
                     }
-                }
+                },
+                "default"
             ).response(
                 new RequestLine("GET", "specs.4.8").toString(),
                 new Headers.From(new Authorization(token)),

--- a/src/test/java/com/artipie/gem/GemCliITCase.java
+++ b/src/test/java/com/artipie/gem/GemCliITCase.java
@@ -39,6 +39,7 @@ import org.cactoos.text.Base64Encoded;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jruby.javasupport.JavaEmbedUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
@@ -104,7 +105,11 @@ public class GemCliITCase {
             String.format("'gem push builder-3.2.4.gem failed with non-zero code", hostf),
             this.bash(
                 ruby,
-                String.format("GEM_HOST_API_KEY=%s gem push builder-3.2.4.gem --host %s", key, hostf)
+                String.format(
+                    "GEM_HOST_API_KEY=%s gem push builder-3.2.4.gem --host %s",
+                    key,
+                    hostf
+                )
             ),
             Matchers.equalTo(0)
         );
@@ -112,7 +117,11 @@ public class GemCliITCase {
             String.format("'gem push rails-6.0.2.2.gem failed with non-zero code", hostf),
             this.bash(
                 ruby,
-                String.format("GEM_HOST_API_KEY=%s gem push rails-6.0.2.2.gem --host %s", key, hostf)
+                String.format(
+                    "GEM_HOST_API_KEY=%s gem push rails-6.0.2.2.gem --host %s",
+                    key,
+                    hostf
+                )
             ),
             Matchers.equalTo(0)
         );
@@ -120,7 +129,11 @@ public class GemCliITCase {
             String.format("'gem push rails-6.0.2.2.gem failed with non-zero code", hostf),
             this.bash(
                 ruby,
-                String.format("GEM_HOST_API_KEY=%s gem push builder-3.2.4.gem --host %s", key, hosts)
+                String.format(
+                    "GEM_HOST_API_KEY=%s gem push rails-6.0.2.2.gem --host %s",
+                    key,
+                    hosts
+                )
             ),
             Matchers.equalTo(0)
         );
@@ -142,16 +155,16 @@ public class GemCliITCase {
             ),
             Matchers.equalTo(0)
         );
-        MatcherAssert.assertThat(
-            String.format(
-                "'gem fetch should fail, since builder was not pushed to the second repo",
-                hostf
-            ),
-            this.bash(
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> this.bash(
                 ruby,
                 String.format("GEM_HOST_API_KEY=%s gem fetch -V builder --source %s", key, hosts)
             ),
-            Matchers.equalTo(0)
+            String.format(
+                "'gem fetch should fail, since builder was not pushed to the second repo",
+                hostf
+            )
         );
         ruby.stop();
         first.close();

--- a/src/test/java/com/artipie/gem/GemCliITCase.java
+++ b/src/test/java/com/artipie/gem/GemCliITCase.java
@@ -54,7 +54,7 @@ import org.testcontainers.containers.GenericContainer;
  * @checkstyle StringLiteralsConcatenationCheck (500 lines)
  * @checkstyle ExecutableStatementCountCheck (500 lines)
  */
-@SuppressWarnings("PMD.SystemPrintln")
+@SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.AvoidDuplicateLiterals"})
 @DisabledIfSystemProperty(named = "os.name", matches = "Windows.*")
 public class GemCliITCase {
 

--- a/src/test/java/com/artipie/gem/GemCliITCase.java
+++ b/src/test/java/com/artipie/gem/GemCliITCase.java
@@ -24,6 +24,8 @@
 package com.artipie.gem;
 
 import com.artipie.asto.fs.FileStorage;
+import com.artipie.http.auth.Authentication;
+import com.artipie.http.auth.Permissions;
 import com.artipie.vertx.VertxSliceServer;
 import com.jcabi.log.Logger;
 import io.vertx.reactivex.core.Vertx;
@@ -31,9 +33,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Optional;
 import org.cactoos.text.Base64Encoded;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.jruby.javasupport.JavaEmbedUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
@@ -59,7 +64,13 @@ public class GemCliITCase {
         final Vertx vertx = Vertx.vertx();
         final VertxSliceServer server = new VertxSliceServer(
             vertx,
-            new GemSlice(new FileStorage(temp))
+            new GemSlice(
+                new FileStorage(temp),
+                JavaEmbedUtils.initialize(new ArrayList<>(0)),
+                Permissions.FREE,
+                (login, pwd) -> Optional.of(new Authentication.User("anonymous")),
+                "gemPushAndInstallWorks"
+            )
         );
         final int port = server.start();
         final String host = String.format("http://host.testcontainers.internal:%d", port);

--- a/src/test/java/com/artipie/gem/SubmitGemITCase.java
+++ b/src/test/java/com/artipie/gem/SubmitGemITCase.java
@@ -24,6 +24,7 @@
 package com.artipie.gem;
 
 import com.artipie.asto.fs.FileStorage;
+import com.artipie.http.auth.Permissions;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.vertx.VertxSliceServer;
 import io.vertx.reactivex.core.Vertx;
@@ -33,8 +34,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.jruby.javasupport.JavaEmbedUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -50,7 +54,13 @@ public class SubmitGemITCase {
         final Vertx vertx = Vertx.vertx();
         final VertxSliceServer server = new VertxSliceServer(
             vertx,
-            new GemSlice(new FileStorage(temp))
+            new GemSlice(
+                new FileStorage(temp),
+                JavaEmbedUtils.initialize(new ArrayList<>(0)),
+                Permissions.FREE,
+                (lgn, pwd) -> Optional.empty(),
+                "submitResultsInOkResponse"
+            )
         );
         final WebClient web = WebClient.create(vertx);
         final int port = server.start();


### PR DESCRIPTION
Test is not required for this PR.

Instead of "temp-gem-index", a name with random uuid is used as a temp dir.

Closes #76 