### PR TITLE
Issue #104 Rename gem to its name and version

### DIFF
--- a/src/main/java/com/artipie/gem/Gem.java
+++ b/src/main/java/com/artipie/gem/Gem.java
@@ -99,7 +99,12 @@ public final class Gem {
                 .thenApply(ignore -> tmp)
         ).thenCompose(
             tmp -> this.shared.apply(RubyGemIndex::new)
-                .thenAccept(index -> index.update(tmp))
+                .thenAccept(
+                    index -> {
+                        final Path dir = Paths.get(tmp.toString(), gem.string());
+                        index.rename(dir);
+                        index.update(tmp);
+                    })
                 .thenCompose(none -> new Copy(new FileStorage(tmp)).copy(this.storage))
                 .handle(removeTempDir(tmp))
         );

--- a/src/main/java/com/artipie/gem/Gem.java
+++ b/src/main/java/com/artipie/gem/Gem.java
@@ -102,8 +102,7 @@ public final class Gem {
                 .thenAccept(
                     index -> {
                         final Path dir = Paths.get(tmp.toString(), gem.string());
-                        index.rename(dir);
-                        index.update(tmp);
+                        index.update(dir);
                     })
                 .thenCompose(none -> new Copy(new FileStorage(tmp)).copy(this.storage))
                 .handle(removeTempDir(tmp))

--- a/src/main/java/com/artipie/gem/ruby/RubyGemIndex.java
+++ b/src/main/java/com/artipie/gem/ruby/RubyGemIndex.java
@@ -62,4 +62,27 @@ public final class RubyGemIndex implements GemIndex {
             )
         );
     }
+
+    /**
+     * Renames local file.
+     *
+     * @param path Full path too gem file.
+     */
+    public void rename(final Path path) {
+        final RubyRuntimeAdapter adapter = JavaEmbedUtils.newRuntimeAdapter();
+        adapter.eval(this.ruby, "require 'rubygems/package.rb'");
+        adapter.eval(
+            this.ruby,
+            String.format(
+                "ind='%s'.rindex('/')\n"
+                    .concat("dir='' if ind == nil \n")
+                    .concat("dir='%s'[0,ind+1] if ind != nil \n")
+                    .concat("spec=Gem::Package.new('%s').spec \n")
+                    .concat("File.rename('%s', dir + spec.name + '-'")
+                    .concat("+ spec.version.version + '.gem')"),
+                path.toAbsolutePath(), path.toAbsolutePath(), path.toAbsolutePath(),
+                path.toAbsolutePath()
+            )
+        );
+    }
 }

--- a/src/main/java/com/artipie/gem/ruby/RubyGemIndex.java
+++ b/src/main/java/com/artipie/gem/ruby/RubyGemIndex.java
@@ -57,31 +57,16 @@ public final class RubyGemIndex implements GemIndex {
         adapter.eval(
             this.ruby,
             String.format(
-                "Gem::Indexer.new('%s', {build_modern:true}).generate_index",
-                path.toAbsolutePath().toString()
-            )
-        );
-    }
-
-    /**
-     * Renames local file.
-     *
-     * @param path Full path too gem file.
-     */
-    public void rename(final Path path) {
-        final RubyRuntimeAdapter adapter = JavaEmbedUtils.newRuntimeAdapter();
-        adapter.eval(this.ruby, "require 'rubygems/package.rb'");
-        adapter.eval(
-            this.ruby,
-            String.format(
                 "ind='%s'.rindex('/')\n"
                     .concat("dir='' if ind == nil \n")
                     .concat("dir='%s'[0,ind+1] if ind != nil \n")
                     .concat("spec=Gem::Package.new('%s').spec \n")
                     .concat("File.rename('%s', dir + spec.name + '-'")
-                    .concat("+ spec.version.version + '.gem')"),
+                    .concat("+ spec.version.version + '.gem') if ")
+                    .concat("!File.file?(dir + spec.name + '-' + spec.version.version + '.gem')\n")
+                    .concat("Gem::Indexer.new('%s', {build_modern:true}).generate_index"),
                 path.toAbsolutePath(), path.toAbsolutePath(), path.toAbsolutePath(),
-                path.toAbsolutePath()
+                path.toAbsolutePath(), path.getParent().getParent().toAbsolutePath()
             )
         );
     }


### PR DESCRIPTION
When a new gem is being pushed with `gem push`, save it not with random name, but use gem name and version