### PR TITLE
Fix Bug: Gem index is replaced on update bug

### DIFF
--- a/src/main/java/com/artipie/gem/Gem.java
+++ b/src/main/java/com/artipie/gem/Gem.java
@@ -28,7 +28,6 @@ import com.artipie.asto.Copy;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.fs.FileStorage;
-import com.artipie.asto.misc.UncheckedConsumer;
 import com.artipie.gem.ruby.RubyGemIndex;
 import com.artipie.gem.ruby.RubyGemMeta;
 import com.artipie.gem.ruby.SharedRuntime;
@@ -112,7 +111,7 @@ public final class Gem {
                         try {
                             Files.move(path, target);
                         } catch (final IOException err) {
-                            throw new ArtipieException(err);
+                            throw new ArtipieIOException(err);
                         }
                         return target;
                     }

--- a/src/main/java/com/artipie/gem/Gem.java
+++ b/src/main/java/com/artipie/gem/Gem.java
@@ -105,19 +105,27 @@ public final class Gem {
                         Paths.get(tmp.toString(), gem.string()),
                         spec -> String.format("%s-%s.gem", spec.get("name"), spec.get("version"))
                     )
-                ).thenAccept(
-                    new UncheckedConsumer<>(
-                        name -> {
-                            final Path path = Paths.get(tmp.toString(), gem.string());
-                            Files.move(path, path.getParent().resolve(name));
+                ).thenApply(
+                    name -> {
+                        final Path path = Paths.get(tmp.toString(), gem.string());
+                        final Path target = path.getParent().resolve(name);
+                        try {
+                            Files.move(path, target);
+                        } catch (final IOException err) {
+                            throw new ArtipieException(err);
                         }
-                    )
-                ).thenApply(none -> tmp)
+                        return target;
+                    }
+                )
         ).thenCompose(
             tmp -> this.shared.apply(RubyGemIndex::new)
                 .thenAccept(index -> index.update(tmp))
-                .thenCompose(none -> new Copy(new FileStorage(tmp)).copy(this.storage))
-                .handle(removeTempDir(tmp))
+                .thenCompose(
+                    none -> new Copy(
+                        new FileStorage(tmp.getParent().getParent())
+                    ).copy(this.storage)
+                )
+                .handle(removeTempDir(tmp.getParent().getParent()))
         );
     }
 

--- a/src/main/ruby/metarunner.rb
+++ b/src/main/ruby/metarunner.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'updatemeta.rb'
+
+class MetaRunner
+
+    def initialize(val)
+        Ex.new(val).info()
+        puts val
+    end
+end

--- a/src/main/ruby/updatemeta.rb
+++ b/src/main/ruby/updatemeta.rb
@@ -3,35 +3,45 @@ require 'rubygems'
 require 'rubygems/package'
 require 'time'
 require 'tmpdir'
-require 'digest'
-require 'json'
 require 'java'
 
 class Ex
-    include com.artipie.gem.IRubyInfo
-
     def initialize(val)
         @val = val
     end
 
     def info()
-        spec = Gem::Package.new(@val).spec
-        metas = Marshal.load(File.open("latest_specs.4.8").read)
-        found = false
-        metas.each do |item|
-            if item[0] == spec.name && item[1].version == spec.version.version
-                found = true
-                puts 'Found specification'
+        puts "222222"
+        puts @val
+        begin
+            spec = Gem::Package.new(@val).spec()
+            found = false
+            metas = []
+            if File.file?("latest_specs.4.8") and File.size("latest_specs.4.8") > 10
+                puts "Check latest"
+                content = File.open("latest_specs.4.8").read
+                puts content
+                metas = Marshal.load(content)
+                metas.each do |item|
+                    if item[0] == spec.name && item[1].version == spec.version.version
+                        found = true
+                        puts 'Found specification'
+                    end
+                end
             end
-        end
-        if found == false
-            puts 'Did not found specification'
-            metas.push([spec.name, Gem::Version.create(spec.version.version), "ruby"])
-            data = Marshal.dump(metas)
-            File.write('latest_specs.4.8', data)
-            Zlib::GzipWriter.open('latest_specs.4.8.gz') do |gz|
-                gz.write data
+            if found == false
+                puts 'Did not found specification'
+                metas.push([spec.name, Gem::Version.create(spec.version.version), "ruby"])
+                data = Marshal.dump(metas)
+                File.write('latest_specs.4.8', data)
+                Zlib::GzipWriter.open('latest_specs.4.8.gz') do |gz|
+                    gz.write data
+                end
+                puts "Final spec"
+       	        puts data
             end
+        rescue Exception => e
+            puts e
         end
     end
 end

--- a/src/main/ruby/updatemeta.rb
+++ b/src/main/ruby/updatemeta.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rubygems'
+require 'rubygems/package'
+require 'time'
+require 'tmpdir'
+require 'digest'
+require 'json'
+require 'java'
+
+class Ex
+    include com.artipie.gem.IRubyInfo
+
+    def initialize(val)
+        @val = val
+    end
+
+    def info()
+        sha = Digest::SHA2.new
+        File.open(@val) do |f|
+            while chunk = f.read(256)
+                sha << chunk
+            end
+        end
+        spec = Gem::Package.new(@val).spec
+        authors = ""
+        spec.authors.each do |author|
+            if authors.length > 0
+                authors = authors + ", "
+            end
+            authors = authors + author
+        end
+        deps = spec.dependencies
+        development = []
+        runtime = []
+        deps.each do |item|
+            if item.type == :runtime
+                runtime.push({'name' => item.name, 'requirements' => item.requirements_list()[0]})
+            else
+                development.push({'name' => item.name, 'requirements' => item.requirements_list()[0]})
+            end
+        end
+        info = {'name' => spec.name, 'version' => spec.version.version, 'sha' => sha.hexdigest, 'info' => spec.description, 'authors' => authors, 'homepage_uri' => spec.homepage, 'dependencies' => {'development' => development, 'runtime' => runtime}}
+        return info.to_json
+    end
+end

--- a/src/main/ruby/updatemeta.rb
+++ b/src/main/ruby/updatemeta.rb
@@ -11,35 +11,54 @@ class Ex
     end
 
     def info()
-        puts "222222"
-        puts @val
         begin
             spec = Gem::Package.new(@val).spec()
             found = false
             metas = []
             if File.file?("latest_specs.4.8") and File.size("latest_specs.4.8") > 10
-                puts "Check latest"
                 content = File.open("latest_specs.4.8").read
-                puts content
                 metas = Marshal.load(content)
                 metas.each do |item|
                     if item[0] == spec.name && item[1].version == spec.version.version
                         found = true
-                        puts 'Found specification'
+                        puts 'Found specification in latest'
                     end
                 end
             end
             if found == false
-                puts 'Did not found specification'
+                puts 'Did not found specification in latest'
                 metas.push([spec.name, Gem::Version.create(spec.version.version), "ruby"])
                 data = Marshal.dump(metas)
                 File.write('latest_specs.4.8', data)
                 Zlib::GzipWriter.open('latest_specs.4.8.gz') do |gz|
                     gz.write data
                 end
-                puts "Final spec"
-       	        puts data
             end
+
+
+
+            found = false
+            metas = []
+            if File.file?("specs.4.8") and File.size("specs.4.8") > 10
+                content = File.open("specs.4.8").read
+                metas = Marshal.load(content)
+                metas.each do |item|
+                    if item[0] == spec.name && item[1].version == spec.version.version
+                        found = true
+                        puts 'Found specification in specs'
+                    end
+                end
+            end
+            if found == false
+                puts 'Did not found specification in specs'
+                metas.push([spec.name, Gem::Version.create(spec.version.version), "ruby"])
+                data = Marshal.dump(metas)
+                File.write('specs.4.8', data)
+                Zlib::GzipWriter.open('specs.4.8.gz') do |gz|
+                    gz.write data
+                end
+            end
+
         rescue Exception => e
             puts e
         end


### PR DESCRIPTION
close #114 

When a new gem is being pushed, `latest_spec` and `spec` add information for a new gem, keep existing data without rewrite.