### PR TITLE
feat: gem v1 dependencies API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,18 @@ SOFTWARE.
       <groupId>wtf.g4s8</groupId>
       <artifactId>matchers-json</artifactId>
       <version>1.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-platform.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>wtf.g4s8</groupId>
+      <artifactId>tuples</artifactId>
+      <version>0.1.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/artipie/gem/GemKeyPredicate.java
+++ b/src/main/java/com/artipie/gem/GemKeyPredicate.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.gem;
+
+import com.artipie.asto.Key;
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * Gem key predicate with specified names to match.
+ * @since 1.3
+ */
+final class GemKeyPredicate implements Predicate<Key> {
+
+    /**
+     * Gem tail pattern.
+     */
+    private static final Pattern PTN_TAIL = Pattern.compile("^[0-9a-zA-Z\\-\\.]+\\.gem$");
+
+    /**
+     * Gem names.
+     */
+    private final Set<? extends String> names;
+
+    /**
+     * New predicate with one name.
+     * @param name Gem name
+     */
+    GemKeyPredicate(final String name) {
+        this(Collections.singleton(name));
+    }
+
+    /**
+     * New predicate with multiple gem names.
+     * @param names Gem names
+     */
+    GemKeyPredicate(final Set<? extends String> names) {
+        this.names = names;
+    }
+
+    @Override
+    public boolean test(final Key target) {
+        final String gem = target.string();
+        return this.names.stream().anyMatch(name -> testOne(name, gem));
+    }
+
+    /**
+     * Test one item.
+     * @param name Gem name
+     * @param target Item target
+     * @return True if target matches
+     */
+    private static boolean testOne(final String name, final String target) {
+        final int idx = target.lastIndexOf(name);
+        boolean matches = false;
+        if (idx >= 0) {
+            final String tail = target.substring(idx + name.length());
+            if (tail.isEmpty() || PTN_TAIL.matcher(tail).matches()) {
+                matches = true;
+            }
+        }
+        return matches;
+    }
+
+}

--- a/src/main/java/com/artipie/gem/http/ApiGetSlice.java
+++ b/src/main/java/com/artipie/gem/http/ApiGetSlice.java
@@ -33,7 +33,7 @@ import org.reactivestreams.Publisher;
  *
  * @since 0.2
  */
-public final class ApiGetSlice implements Slice {
+final class ApiGetSlice implements Slice {
 
     /**
      * Endpoint path pattern.
@@ -50,7 +50,7 @@ public final class ApiGetSlice implements Slice {
      * New slice for handling Get API requests.
      * @param storage Gems storage
      */
-    public ApiGetSlice(final Storage storage) {
+    ApiGetSlice(final Storage storage) {
         this.sdk = new Gem(storage);
     }
 

--- a/src/main/java/com/artipie/gem/http/ApiKeySlice.java
+++ b/src/main/java/com/artipie/gem/http/ApiKeySlice.java
@@ -25,7 +25,7 @@ import org.reactivestreams.Publisher;
  *
  * @since 0.3
  */
-public final class ApiKeySlice implements Slice {
+final class ApiKeySlice implements Slice {
 
     /**
      * The users.
@@ -36,7 +36,7 @@ public final class ApiKeySlice implements Slice {
      * The Ctor.
      * @param auth Auth.
      */
-    public ApiKeySlice(final Authentication auth) {
+    ApiKeySlice(final Authentication auth) {
         this.auth = auth;
     }
 

--- a/src/main/java/com/artipie/gem/http/DepsGemSlice.java
+++ b/src/main/java/com/artipie/gem/http/DepsGemSlice.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.gem.http;
+
+import com.artipie.asto.Storage;
+import com.artipie.gem.Gem;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.rq.RequestLineFrom;
+import com.artipie.http.rq.RqParams;
+import com.artipie.http.rs.RsWithBody;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import org.reactivestreams.Publisher;
+
+/**
+ * Dependency API slice implementation.
+ * @since 1.3
+ */
+final class DepsGemSlice implements Slice {
+
+    /**
+     * Repository storage.
+     */
+    private final Storage repo;
+
+    /**
+     * New dependency slice.
+     * @param repo Repository storage
+     */
+    DepsGemSlice(final Storage repo) {
+        this.repo = repo;
+    }
+
+    @Override
+    public Response response(final String line, final Iterable<Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body) {
+        return new AsyncResponse(
+            new Gem(this.repo).dependencies(
+                Collections.unmodifiableSet(
+                    new HashSet<>(
+                        new RqParams(new RequestLineFrom(line).uri().getQuery()).value("gems")
+                            .map(str -> Arrays.asList(str.split(",")))
+                            .orElse(Collections.emptyList())
+                    )
+                )
+            ).thenApply(
+                data -> new RsWithBody(Flowable.just(data))
+            )
+        );
+    }
+}

--- a/src/main/java/com/artipie/gem/http/GemSlice.java
+++ b/src/main/java/com/artipie/gem/http/GemSlice.java
@@ -60,7 +60,7 @@ public final class GemSlice extends Slice.Wrap {
             new SliceRoute(
                 new RtRulePath(
                     new RtRule.All(
-                        new ByMethodsRule(RqMethod.POST),
+                        ByMethodsRule.Standard.POST,
                         new RtRule.ByPath("/api/v1/gems")
                     ),
                     new AuthSlice(
@@ -74,11 +74,11 @@ public final class GemSlice extends Slice.Wrap {
                         ByMethodsRule.Standard.GET,
                         new RtRule.ByPath("/api/v1/dependencies")
                     ),
-                    new SliceSimple(new RsWithStatus(RsStatus.NOT_IMPLEMENTED))
+                    new DepsGemSlice(storage)
                 ),
                 new RtRulePath(
                     new RtRule.All(
-                        new ByMethodsRule(RqMethod.GET),
+                        ByMethodsRule.Standard.GET,
                         new RtRule.ByPath("/api/v1/api_key")
                     ),
                     new ApiKeySlice(auth)

--- a/src/main/java/com/artipie/gem/http/SubmitGemSlice.java
+++ b/src/main/java/com/artipie/gem/http/SubmitGemSlice.java
@@ -22,7 +22,7 @@ import org.reactivestreams.Publisher;
  * A slice, which servers gem packages.
  * @since 1.0
  */
-public final class SubmitGemSlice implements Slice {
+final class SubmitGemSlice implements Slice {
 
     /**
      * Repository storage.
@@ -39,7 +39,7 @@ public final class SubmitGemSlice implements Slice {
      *
      * @param storage The storage.
      */
-    public SubmitGemSlice(final Storage storage) {
+    SubmitGemSlice(final Storage storage) {
         this.storage = storage;
         this.gem = new Gem(storage);
     }

--- a/src/test/java/com/artipie/gem/GemCliITCase.java
+++ b/src/test/java/com/artipie/gem/GemCliITCase.java
@@ -21,7 +21,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
@@ -136,7 +135,6 @@ final class GemCliITCase {
     }
 
     @Test
-    @Disabled
     void gemBundleInstall() throws Exception {
         final Set<String> gems = new HashSet<>(
             Arrays.asList(

--- a/src/test/java/com/artipie/gem/GemKeyPredicateTest.java
+++ b/src/test/java/com/artipie/gem/GemKeyPredicateTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.gem;
+
+import com.artipie.asto.Key;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test case for {@link GemKeyPredicate}.
+ * @since 1.3
+ */
+final class GemKeyPredicateTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "builder,builder-3.2.4.gem",
+        "file-tail,file-tail-1.2.0.gem",
+        "gviz,gviz-0.3.5.gem",
+        "rails,rails-6.0.2.2.gem",
+        "builder,gems/builder-3.2.4.gem"
+    })
+    void testCorrectItems(final String name, final String target) {
+        MatcherAssert.assertThat(
+            String.format("`%s` not matched by `%s`", target, name),
+            new GemKeyPredicate(name).test(new Key.From(target)),
+            Matchers.is(true)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "builder,builder-3.2.4",
+        "file-tail,file-tail.gem",
+        "gviz,builder-0.3.5.gem",
+        "rails,6.0.2.2.gem"
+    })
+    void testWrongItems(final String name, final String target) {
+        MatcherAssert.assertThat(
+            String.format("`%s` matched by `%s`", target, name),
+            new GemKeyPredicate(name).test(new Key.From(target)),
+            Matchers.is(false)
+        );
+    }
+}

--- a/src/test/java/com/artipie/gem/GemTest.java
+++ b/src/test/java/com/artipie/gem/GemTest.java
@@ -59,7 +59,7 @@ final class GemTest {
             .forEach(tr -> tr.saveTo(new SubStorage(new Key.From("gems"), repo)));
         MatcherAssert.assertThat(
             new Gem(repo).dependencies(
-                new HashSet<>(Arrays.asList("builder-3.2.4", "file-tail-1.2.0"))
+                new HashSet<>(Arrays.asList("builder", "file-tail"))
             ).toCompletableFuture().join().limit(),
             Matchers.greaterThan(0)
         );

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -4,4 +4,4 @@ log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=com.jcabi.log.MulticolorLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=[%color{%p}] %t %c: %m%n
 
-log4j.logger.com.artipie=DEBUG
+log4j.logger.com.artipie.gem=DEBUG


### PR DESCRIPTION
Added dependencies `Slice` implementation for v1 API,
removed `@Disabled` annotation for test.
Discovered bug in dependencies SDK test, fixed copy
predicate to filter keys by gem names, fixed test.

Close: #97 