### PR TITLE
fix: gem info output fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>v1.3.0</version>
+      <version>v1.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -95,12 +95,6 @@ SOFTWARE.
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit-platform.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -155,7 +149,7 @@ SOFTWARE.
     <dependency>
       <groupId>wtf.g4s8</groupId>
       <artifactId>matchers-json</artifactId>
-      <version>1.0.2</version>
+      <version>1.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/artipie/gem/Gem.java
+++ b/src/main/java/com/artipie/gem/Gem.java
@@ -216,6 +216,11 @@ public final class Gem {
         }
 
         @Override
+        public void print(final String nme, final String[] values) {
+            // do nothing
+        }
+
+        @Override
         public String toString() {
             return String.format("%s-%s.gem", this.name, this.version);
         }

--- a/src/main/java/com/artipie/gem/GemMeta.java
+++ b/src/main/java/com/artipie/gem/GemMeta.java
@@ -38,6 +38,14 @@ public interface GemMeta {
          * @param value Node
          */
         void print(String name, MetaInfo value);
+
+        /**
+         * Print array of strings.
+         * @param name Key
+         * @param values Array
+         */
+        @SuppressWarnings("PMD.UseVarargs")
+        void print(String name, String[] values);
     }
 
     /**

--- a/src/main/java/com/artipie/gem/JsonMetaFormat.java
+++ b/src/main/java/com/artipie/gem/JsonMetaFormat.java
@@ -7,6 +7,7 @@ package com.artipie.gem;
 import com.artipie.gem.GemMeta.MetaFormat;
 import com.artipie.gem.GemMeta.MetaInfo;
 import javax.json.Json;
+import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
 
 /**
@@ -41,5 +42,14 @@ public final class JsonMetaFormat implements MetaFormat {
         final JsonObjectBuilder child = Json.createObjectBuilder();
         value.print(new JsonMetaFormat(child));
         this.builder.add(name, child);
+    }
+
+    @Override
+    public void print(final String name, final String[] values) {
+        final JsonArrayBuilder arb = Json.createArrayBuilder();
+        for (final String item : values) {
+            arb.add(item);
+        }
+        this.builder.add(name, arb);
     }
 }

--- a/src/main/java/com/artipie/gem/ruby/RubyGemMeta.java
+++ b/src/main/java/com/artipie/gem/ruby/RubyGemMeta.java
@@ -7,12 +7,20 @@ package com.artipie.gem.ruby;
 import com.artipie.gem.GemMeta;
 import java.nio.file.Path;
 import org.jruby.Ruby;
+import org.jruby.RubyArray;
 import org.jruby.RubyObject;
 import org.jruby.javasupport.JavaEmbedUtils;
+import org.jruby.runtime.builtin.IRubyObject;
 
 /**
  * JRuby implementation of GemInfo metadata parser.
  * @since 1.0
+ * @todo #103:30min Inspect rubygems API response to add more fields.
+ *  Check responses for different Gem requests for origin rubygems.org
+ *  or reverse-engineer Gem repository Ruby code to understand all fields
+ *  that should be added to gems API response. Now all mandatory fields
+ *  are present in this metadata genrator but different gem responses may have
+ *  optional fields. E.g. https://rubygems.org/api/v1/gems/builder.json
  */
 public final class RubyGemMeta implements GemMeta, SharedRuntime.RubyPlugin {
 
@@ -70,14 +78,41 @@ public final class RubyGemMeta implements GemMeta, SharedRuntime.RubyPlugin {
         }
 
         @Override
+        @SuppressWarnings("PMD.AvoidDuplicateLiterals")
         public void print(final MetaFormat fmt) {
-            this.spec.getVariableList().stream()
-                .filter(item -> item.getValue() != null).forEach(
-                    node -> fmt.print(
-                        node.getName().substring(1),
-                        node.getValue().toString()
-                    )
+            fmt.print("name", this.spec.getInstanceVariable("@name").asJavaString());
+            fmt.print(
+                "version",
+                this.spec.getInstanceVariable("@version")
+                    .getInstanceVariables()
+                    .getInstanceVariable("@version")
+                    .asJavaString()
             );
+            fmt.print("platform", this.spec.getInstanceVariable("@platform").asJavaString());
+            fmt.print(
+                "authors",
+                rubyToJavaStringArray(this.spec.getInstanceVariable("@authors").convertToArray())
+            );
+            fmt.print("info", this.spec.getInstanceVariable("@description").asJavaString());
+            fmt.print(
+                "licenses",
+                rubyToJavaStringArray(this.spec.getInstanceVariable("@licenses").convertToArray())
+            );
+            fmt.print("homepage_uri", this.spec.getInstanceVariable("@homepage").asJavaString());
+        }
+
+        /**
+         * Convert JRuby array to Java array of stirngs.
+         * @param src JRuby array
+         * @return String array
+         */
+        private static String[] rubyToJavaStringArray(final RubyArray<?> src) {
+            final IRubyObject[] jarr = src.toJavaArray();
+            final String[] res = new String[jarr.length];
+            for (int id = 0; id < jarr.length; ++id) {
+                res[id] = jarr[id].asJavaString();
+            }
+            return res;
         }
     }
 }

--- a/src/test/java/com/artipie/gem/http/ApiGetSliceTest.java
+++ b/src/test/java/com/artipie/gem/http/ApiGetSliceTest.java
@@ -5,6 +5,7 @@
 package com.artipie.gem.http;
 
 import com.artipie.asto.fs.FileStorage;
+import com.artipie.asto.test.TestResource;
 import com.artipie.http.Headers;
 import com.artipie.http.hm.IsJson;
 import com.artipie.http.hm.RsHasBody;
@@ -12,17 +13,11 @@ import com.artipie.http.hm.SliceHasResponse;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import wtf.g4s8.hamcrest.json.JsonHas;
-import wtf.g4s8.hamcrest.json.JsonValueIs;
 
 /**
  * A test for gem submit operation.
@@ -31,27 +26,13 @@ import wtf.g4s8.hamcrest.json.JsonValueIs;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class ApiGetSliceTest {
-
     @Test
     public void queryResultsInOkResponse(@TempDir final Path tmp) throws IOException {
-        final Path target = tmp.resolve("gviz-0.3.5.gem");
-        try (InputStream is = this.getClass().getResourceAsStream("/gviz-0.3.5.gem");
-            OutputStream os = Files.newOutputStream(target)) {
-            IOUtils.copy(is, os);
-        }
+        new TestResource("gviz-0.3.5.gem").saveTo(tmp.resolve("./gviz-0.3.5.gem"));
         MatcherAssert.assertThat(
             new ApiGetSlice(new FileStorage(tmp)),
             new SliceHasResponse(
-                Matchers.allOf(
-                    new RsHasBody(
-                        new IsJson(
-                            new JsonHas(
-                                "homepage",
-                                new JsonValueIs("https://github.com/melborne/Gviz")
-                            )
-                        )
-                    )
-                ),
+                new RsHasBody(new IsJson(new JsonHas("name", "gviz"))),
                 new RequestLine(RqMethod.GET, "/api/v1/gems/gviz.json"),
                 Headers.EMPTY,
                 com.artipie.asto.Content.EMPTY

--- a/src/test/java/com/artipie/gem/ruby/RubyGemMetaTest.java
+++ b/src/test/java/com/artipie/gem/ruby/RubyGemMetaTest.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.gem.ruby;
+
+import com.artipie.asto.test.TestResource;
+import com.artipie.gem.JsonMetaFormat;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import wtf.g4s8.hamcrest.json.JsonContains;
+import wtf.g4s8.hamcrest.json.JsonHas;
+import wtf.g4s8.hamcrest.json.JsonValueIs;
+
+/**
+ * Test case for {@link RubyGemMeta}.
+ * @since 1.3
+ */
+final class RubyGemMetaTest {
+    @Test
+    void generateValidMeta(final @TempDir Path tmp) throws Exception {
+        final Path gem = tmp.resolve("target.gem");
+        Files.write(gem, new TestResource("builder-3.2.4.gem").asBytes());
+        final RubyGemMeta meta = new SharedRuntime().apply(RubyGemMeta::new)
+            .toCompletableFuture().join();
+        final JsonObjectBuilder json = Json.createObjectBuilder();
+        meta.info(gem).print(new JsonMetaFormat(json));
+        MatcherAssert.assertThat(
+            json.build(),
+            Matchers.allOf(
+                new JsonHas("name", "builder"),
+                new JsonHas("version", "3.2.4"),
+                new JsonHas("platform", "ruby"),
+                new JsonHas("authors", new JsonContains(new JsonValueIs("Jim Weirich"))),
+                new JsonHas(
+                    "info",
+                    new JsonValueIs(
+                        Matchers.startsWith("Builder provides a number of builder objects")
+                    )
+                ),
+                new JsonHas("licenses", new JsonContains(new JsonValueIs("MIT"))),
+                new JsonHas("homepage_uri", "http://onestepback.org")
+            )
+        );
+    }
+}


### PR DESCRIPTION
Reverse-engineered mandatory fields and format in gem API response,
selected them from gem spec ruby object, converted to valid
abstract representation of `MetaInfo`, added unit test,
fixed broken tests, added `@todo` for optional fields.

Fixes: #103