### PR TITLE
feat: gem meta yaml format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,11 @@ SOFTWARE.
       <version>1.1.4</version>
     </dependency>
     <dependency>
+      <groupId>com.amihaiemil.web</groupId>
+      <artifactId>eo-yaml</artifactId>
+      <version>5.2.3</version>
+    </dependency>
+    <dependency>
       <groupId>wtf.g4s8</groupId>
       <artifactId>matchers-json</artifactId>
       <version>1.4.0</version>

--- a/src/main/java/com/artipie/gem/YamlMetaFormat.java
+++ b/src/main/java/com/artipie/gem/YamlMetaFormat.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.gem;
+
+import com.amihaiemil.eoyaml.Yaml;
+import com.amihaiemil.eoyaml.YamlMapping;
+import com.amihaiemil.eoyaml.YamlMappingBuilder;
+import com.amihaiemil.eoyaml.YamlSequenceBuilder;
+import com.artipie.gem.GemMeta.MetaFormat;
+import com.artipie.gem.GemMeta.MetaInfo;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+
+/**
+ * New JSON format for Gem meta info.
+ *
+ * @since 1.0
+ * @todo #122:30min Add tests for this class and ApiGetSlice.
+ *  Check that this class produces valid YAMLs as for JsonMetaFormat.
+ *  Also, check that ApiGetSlice returns valid response for `.yaml` suffix
+ *  in response path. Test for `ApiGetSlice` could be quite primitive just to check
+ *  that slice is working fine with yaml. On the other hand `YamlMetaFormatTest`
+ *  must cover all methods of YamlMetaFormat (same as JsonMetaFormatTest).
+ */
+public final class YamlMetaFormat implements MetaFormat {
+
+    /**
+     * Yaml transformations consumer.
+     */
+    private final Consumer<UnaryOperator<YamlMappingBuilder>> yamler;
+
+    /**
+     * New yaml format.
+     * @param yamler Yaml transformation consumer
+     */
+    public YamlMetaFormat(final Consumer<UnaryOperator<YamlMappingBuilder>> yamler) {
+        this.yamler = yamler;
+    }
+
+    @Override
+    public void print(final String name, final String value) {
+        this.yamler.accept(yaml -> yaml.add(name, value));
+    }
+
+    @Override
+    public void print(final String name, final MetaInfo value) {
+        final Yamler child = new Yamler();
+        value.print(new YamlMetaFormat(child));
+        this.yamler.accept(yaml -> yaml.add(name, child.build()));
+    }
+
+    @Override
+    public void print(final String name, final String[] values) {
+        final YamlSequenceBuilder seq = Yaml.createYamlSequenceBuilder();
+        for (final String item : values) {
+            seq.add(item);
+        }
+        this.yamler.accept(yaml -> yaml.add(name, seq.build()));
+    }
+
+    /**
+     * Yaml tranformation consumer with volatile in-memory state.
+     * @implNote This implementation is not thread safe
+     * @since 1.3
+     */
+    public static final class Yamler implements Consumer<UnaryOperator<YamlMappingBuilder>> {
+
+        /**
+         * Memory for yaml builder.
+         */
+        private volatile YamlMappingBuilder yaml;
+
+        /**
+         * New yaml transformation consumer.
+         */
+        public Yamler() {
+            this(Yaml.createYamlMappingBuilder());
+        }
+
+        /**
+         * New Yaml tranfsormation consumer with initial state.
+         * @param yaml Initial Yaml builder
+         */
+        public Yamler(final YamlMappingBuilder yaml) {
+            this.yaml = yaml;
+        }
+
+        @Override
+        public void accept(final UnaryOperator<YamlMappingBuilder> transform) {
+            this.yaml = transform.apply(this.yaml);
+        }
+
+        /**
+         * Build yaml from curren state.
+         * @return Yaml mapping
+         */
+        public YamlMapping build() {
+            return this.yaml.build();
+        }
+    }
+}

--- a/src/main/java/com/artipie/gem/http/ApiGetSlice.java
+++ b/src/main/java/com/artipie/gem/http/ApiGetSlice.java
@@ -6,20 +6,16 @@ package com.artipie.gem.http;
 
 import com.artipie.asto.Storage;
 import com.artipie.gem.Gem;
-import com.artipie.gem.JsonMetaFormat;
 import com.artipie.http.ArtipieHttpException;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsStatus;
-import com.artipie.http.rs.common.RsJson;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.json.Json;
-import javax.json.JsonObjectBuilder;
 import org.reactivestreams.Publisher;
 
 /**
@@ -39,7 +35,7 @@ final class ApiGetSlice implements Slice {
      * Endpoint path pattern.
      */
     public static final Pattern PATH_PATTERN = Pattern
-        .compile("/api/v1/gems/([\\w\\d-]+).(json|yml)");
+        .compile("/api/v1/gems/(?<name>[\\w\\d-]+).(?<fmt>json|yaml)");
 
     /**
      * Gem SDK.
@@ -65,13 +61,8 @@ final class ApiGetSlice implements Slice {
             );
         }
         return new AsyncResponse(
-            this.sdk.info(matcher.group(1)).thenApply(
-                info -> {
-                    final JsonObjectBuilder json = Json.createObjectBuilder();
-                    info.print(new JsonMetaFormat(json));
-                    return json.build();
-                }
-            ).thenApply(json -> new RsJson(json))
+            this.sdk.info(matcher.group("name"))
+                .thenApply(MetaResponseFormat.byName(matcher.group("fmt")))
         );
     }
 }

--- a/src/main/java/com/artipie/gem/http/MetaResponseFormat.java
+++ b/src/main/java/com/artipie/gem/http/MetaResponseFormat.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/artipie/LICENSE.txt
+ */
+package com.artipie.gem.http;
+
+import com.artipie.gem.GemMeta;
+import com.artipie.gem.GemMeta.MetaInfo;
+import com.artipie.gem.JsonMetaFormat;
+import com.artipie.gem.YamlMetaFormat;
+import com.artipie.http.ArtipieHttpException;
+import com.artipie.http.Response;
+import com.artipie.http.headers.ContentType;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithHeaders;
+import com.artipie.http.rs.StandardRs;
+import com.artipie.http.rs.common.RsJson;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.function.Function;
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+
+/**
+ * Gem meta response format.
+ * @since 1.3
+ * @checkstyle ClassDataAbstractionCouplingCheck (100 lines)
+ */
+enum MetaResponseFormat implements Function<GemMeta.MetaInfo, Response> {
+    /**
+     * JSON response format.
+     */
+    JSON {
+        @Override
+        public Response apply(final MetaInfo meta) {
+            final JsonObjectBuilder json = Json.createObjectBuilder();
+            meta.print(new JsonMetaFormat(json));
+            return new RsJson(json.build());
+        }
+    },
+
+    /**
+     * Yaml response format.
+     */
+    YAML {
+        @Override
+        public Response apply(final MetaInfo meta) {
+            final YamlMetaFormat.Yamler yamler = new YamlMetaFormat.Yamler();
+            meta.print(new YamlMetaFormat(yamler));
+            final Charset charset = StandardCharsets.UTF_8;
+            return new RsWithHeaders(
+                new RsWithBody(StandardRs.OK, yamler.build().toString(), charset),
+                new ContentType(
+                    String.format(
+                        "text/x-yaml;charset=%s",
+                        charset.displayName().toLowerCase(Locale.US)
+                    )
+                )
+            );
+        }
+    };
+
+    /**
+     * Format by name.
+     * @param name Format name
+     * @return Response format
+     */
+    static MetaResponseFormat byName(final String name) {
+        final MetaResponseFormat res;
+        switch (name) {
+            case "json":
+                res = MetaResponseFormat.JSON;
+                break;
+            case "yaml":
+                res = MetaResponseFormat.YAML;
+                break;
+            default:
+                throw new ArtipieHttpException(
+                    RsStatus.BAD_REQUEST, String.format("unsupported format type `%s`", name)
+                );
+        }
+        return res;
+    }
+}


### PR DESCRIPTION
Added `YamlMetaFormat` class to produce YAML outputs for Gem spec.
Added `MetaResponseFormat` enum to produce different responses
on format. Integrated response format to `ApiGetSlice` to return
Gem spec metadata based on request path suffix.

Added `@todo` for tests.

Closes: #122